### PR TITLE
Updates License file path to have cleaner output

### DIFF
--- a/src/acparser/__init__.py
+++ b/src/acparser/__init__.py
@@ -180,7 +180,7 @@ def find_license(source_dir) -> str:
         filename = file.lower()
         if filename in license_files:
             license = identify.license_id(os.path.join(source_dir, file))
-            license_filename = os.path.join(source_dir, file)
+            license_filename = file
             break
     return license, license_filename
 

--- a/src/acparser/__init__.py
+++ b/src/acparser/__init__.py
@@ -1,6 +1,6 @@
 "Ansible collection parser for developers."
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 import sys
 import tarfile


### PR DESCRIPTION
Changes license_filepath  from `  /tmp/tmpszx7pqlg/LICENSE`  to `LICENSE`. This enhances readability and the output overall.